### PR TITLE
[feat] modify clustertemplate finalizer logic

### DIFF
--- a/controllers/clustertemplate_controller.go
+++ b/controllers/clustertemplate_controller.go
@@ -66,11 +66,11 @@ func (r *ClusterTemplateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	// if ClusterTemplate was created by claim, claim status must be updated when the ClusterTemplate is deleted
 	if template.GetDeletionTimestamp() != nil && controllerutil.ContainsFinalizer(template, claimFinalizer) {
 		if err := r.updateClaimStatus(reqLogger, template); err != nil {
-			return ctrl.Result{}, err
+			reqLogger.Error(err, "fail to update claim status")
 		}
-
 		controllerutil.RemoveFinalizer(template, claimFinalizer)
-		if r.Client.Update(context.TODO(), template); err != nil {
+		if err := r.Client.Update(context.TODO(), template); err != nil {
+			reqLogger.Error(err, "fail to update template")
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil


### PR DESCRIPTION
 - Situation: When clusterclaim is deleted for clustertemplate exist, the finalizer which located at clustertemplate cause to infinite loop
 - Purpose: prevent infinite reconcile loop
 - Solution: Delete finalizer whether clustertemplatecliam exist or not